### PR TITLE
Set example params in change nodes

### DIFF
--- a/examples/basic-remote-command-example.json
+++ b/examples/basic-remote-command-example.json
@@ -1,69 +1,111 @@
 [
     {
-        "id": "804e2e98.47cbf",
+        "id": "cd7237d9.d91448",
         "type": "tab",
         "label": "ePO Remote Command Example",
         "disabled": false,
-        "info": "This sample invokes and displays the results of a `system.findTag` remote\r\ncommand via the ePO DXL service. The results of the find command are displayed\r\non the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A ePO DXL service is running and available on the DXL fabric. If version 5.0\r\n  or later of the DXL ePO extensions are installed on your ePO server, an ePO\r\n  DXL service should already be running on the fabric. If you are using an\r\n  earlier version of the DXL ePO extensions, you can use the\r\n  [ePO DXL Python Service](https://github.com/opendxl/opendxl-epo-service-python).\r\n* The DXL client associated with the `Find tags in ePO` node is authorized to\r\n  invoke the ePO DXL service, and the user that is connecting to the ePO server\r\n  (within the ePO DXL service) has permission to execute the `system.findTag`\r\n  remote command (see\r\n  [Client Authorization](https://opendxl.github.io/opendxl-epo-client-python/pydoc/authorization.html)).\r\n\r\n### Setup\r\n\r\n* If more than one ePO service is available on the DXL fabric that the DXL\r\n  client is connecting to, edit the `Find tags in ePO` node and set the `ePO Id`\r\n  property to that of the ePO service through which the remote command should be\r\n  performed. By default, the `ePO Id` property is empty, in which case the\r\n  client attempts to dynamically determine the id of the ePO service to\r\n  communicate with.\r\n* Edit the `Set search text` node and modify the `Payload` property with the\r\n  search text to use for the system find tag command. For example:\r\n\r\n  ```json\r\n  {\"searchText\":\"broker\"}\r\n  ```\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Find tags in ePO` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Set search text` node.\r\n\r\n### Output\r\n\r\nThe following output should appear in the Node-RED `debug` tab:\r\n\r\n```\r\n▶ [ object ]\r\n```\r\n\r\nAfter clicking on the right arrow button to expand the contents of the object,\r\noutput similar to the following should appear\r\n\r\n```\r\n▼ 0: object\r\n  tagId: 3\r\n  tagName: \"DXLBROKER\"\r\n  tagNotes: \"DXL Broker\"\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Set search text\r\n\r\nThis is an `inject` input node which starts the flow. This node injects a new\r\nmessage with a JSON-formatted document as the `payload`. The document\r\nspecifies the parameters to use for the ePO remote command. The parameters for\r\nthe \"system.findTag\" command include a `searchText` key with a corresponding\r\nvalue to be used as the text for the search.\r\n\r\nTo see the full list of remote commands and parameters that the ePO server\r\nsupports, a node which invokes the `core.help` remote command with an\r\nempty JSON document `{}` as the `payload` parameter could be included in a flow.\r\n\r\n#### Find tags in ePO\r\n\r\nThis is an `epo remote command` node. This node connects to the DXL fabric and\r\nsends a DXL `Request` message to the ePO service.\r\n\r\nThe `Command` property specifies the target remote command as `system.findTag`.\r\n\r\nThe DXL request message contains parameters set in the `payload` by the\r\n`Set search text` node.\r\n \r\nThe `Return` property is set to \"a parsed JSON object\" and the `Format` property\r\nis set to \"JSON\" to indicate that the payload for the response should be\r\nadded to the output message as a JavaScript object decoded from JSON.\r\n\r\n#### Output tags\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Find tags in ePO` node. The output should include the\r\nresponse received from the DXL fabric for the `system.findTag` command.\r\n"
+        "info": "This sample invokes and displays the results of a `system.findTag` remote\r\ncommand via the ePO DXL service. The results of the find command are displayed\r\non the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A ePO DXL service is running and available on the DXL fabric. If version 5.0\r\n  or later of the DXL ePO extensions are installed on your ePO server, an ePO\r\n  DXL service should already be running on the fabric. If you are using an\r\n  earlier version of the DXL ePO extensions, you can use the\r\n  [ePO DXL Python Service](https://github.com/opendxl/opendxl-epo-service-python).\r\n* The DXL client associated with the `Find tags in ePO` node is authorized to\r\n  invoke the ePO DXL service, and the user that is connecting to the ePO server\r\n  (within the ePO DXL service) has permission to execute the `system.findTag`\r\n  remote command (see\r\n  [Client Authorization](https://opendxl.github.io/opendxl-epo-client-python/pydoc/authorization.html)).\r\n\r\n### Setup\r\n\r\n* Edit the `Set remote command request parameters` node.\r\n\r\n  * Set the value for the `msg.command` rule to the name of the remote command\r\n    to be performed. The default value for this example, `system.findTag`, uses\r\n    a remote command which finds available tags on the ePO server.\r\n\r\n    To see the full list of remote commands and parameters that the ePO server\r\n    supports, a node which invokes the `core.help` remote command with an empty\r\n    JSON document `{}` as the `payload` parameter could be\r\n    included in a flow.\r\n\r\n  * Set the properties under the `msg.payload` object for any parameters\r\n    to include for the remote command.\r\n\r\n    By default, the `msg.payload.searchText` rule is included to specify the\r\n    search text to use for the system find tag command. The value for the\r\n    `msg.payload.searchText` rule could be set to `broker` to find all tags\r\n    which include `broker` in the name.\r\n\r\n  * If more than one ePO service is available on the DXL fabric that the DXL\r\n    client is connecting to, set the value for the `msg.epoUniqueId` rule to\r\n    the ID of the ePO service through which the remote command should be\r\n    performed.\r\n \r\n    By default, the `msg.epoUniqueId` property is empty, in which case the\r\n    client attempts to dynamically determine the ID of the ePO service to\r\n    communicate with.\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Find tags in ePO` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Start flow` node.\r\n\r\n### Output\r\n\r\nThe following output should appear in the Node-RED `debug` tab:\r\n\r\n```\r\n▶ [ object ]\r\n```\r\n\r\nAfter clicking on the right arrow button to expand the contents of the object,\r\noutput similar to the following should appear\r\n\r\n```\r\n▼ 0: object\r\n  tagId: 3\r\n  tagName: \"DXLBROKER\"\r\n  tagNotes: \"DXL Broker\"\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts the flow.\r\n\r\n#### Set remote command request parameters\r\n\r\nThis node sets the value for the `command` property on the message to the name\r\nof the remote command to be invoked on the ePO server. This node also sets a\r\nvalue for the `searchText` property on the `msg.payload` object. The \r\n`searchText` property is supplied as a parameter to the `system.findTag` remote\r\ncommand and is used as the text for the search. This node also sets a value for\r\nthe `msg.epoUniqueId` property. If the value is not empty, it is used as the\r\nunique ID of the ePO server which the remote command is sent to.\r\n\r\n#### Invoke ePO remote command\r\n\r\nThis is an `epo remote command` node. This node connects to the DXL fabric and\r\nsends a DXL `Request` message to the ePO service. The DXL request message\r\ncontains parameters set in the `Set remote command request parameters` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" and the `Format` property\r\nis set to \"JSON\" to indicate that the payload for the response should be\r\nadded to the output message as a JavaScript object decoded from JSON.\r\n\r\n#### Output tags\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Invoke ePO remote command` node. The output should include\r\nthe response received from the DXL fabric for the `system.findTag` command.\r\n"
     },
     {
-        "id": "d97b5c6d.c408f",
+        "id": "5b7bd0f6.0e4d2",
         "type": "dxl-epo-remote-command",
-        "z": "804e2e98.47cbf",
-        "name": "Find tags in ePO",
-        "command": "system.findTag",
+        "z": "cd7237d9.d91448",
+        "name": "",
+        "command": "",
+        "epoUniqueId": "",
         "client": "",
         "returnType": "obj",
-        "x": 330,
-        "y": 100,
+        "x": 370,
+        "y": 300,
         "wires": [
             [
-                "b273de3e.5fb43"
+                "3f69ab2e.585bc4"
             ]
         ]
     },
     {
-        "id": "6bb5aca0.0eb844",
+        "id": "115d8f0d.110cd1",
         "type": "inject",
-        "z": "804e2e98.47cbf",
-        "name": "Set search text",
+        "z": "cd7237d9.d91448",
+        "name": "Start flow",
         "topic": "",
-        "payload": "{\"searchText\":\"<specify-search-text>\"}",
+        "payload": "{}",
         "payloadType": "json",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 140,
+        "x": 100,
         "y": 100,
         "wires": [
             [
-                "d97b5c6d.c408f"
+                "4406c82d.7e6238"
             ]
         ]
     },
     {
-        "id": "b273de3e.5fb43",
+        "id": "3f69ab2e.585bc4",
         "type": "debug",
-        "z": "804e2e98.47cbf",
+        "z": "cd7237d9.d91448",
         "name": "Output tags",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "payload",
-        "x": 510,
-        "y": 100,
+        "x": 610,
+        "y": 300,
         "wires": []
     },
     {
-        "id": "24accb86.c71b94",
+        "id": "6d1c1c8a.602274",
         "type": "comment",
-        "z": "804e2e98.47cbf",
-        "name": "Supply the tag search text to use in the 'Set search text' node ",
+        "z": "cd7237d9.d91448",
+        "name": "Supply the command name and parameters in the 'Set remote command request parameters' node",
         "info": "",
-        "x": 260,
+        "x": 360,
         "y": 40,
         "wires": []
+    },
+    {
+        "id": "4406c82d.7e6238",
+        "type": "change",
+        "z": "cd7237d9.d91448",
+        "name": "Set remote command request parameters",
+        "rules": [
+            {
+                "t": "set",
+                "p": "command",
+                "pt": "msg",
+                "to": "system.findTag",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload.searchText",
+                "pt": "msg",
+                "to": "<specify-search-text>",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "epoUniqueId",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 260,
+        "y": 200,
+        "wires": [
+            [
+                "5b7bd0f6.0e4d2"
+            ]
+        ]
     }
 ]

--- a/examples/basic-system-apply-tag-example.json
+++ b/examples/basic-system-apply-tag-example.json
@@ -1,74 +1,88 @@
 [
     {
-        "id": "a0a509be.5e6768",
+        "id": "59a70ee6.117af",
         "type": "tab",
         "label": "ePO System Apply Tag Example",
         "disabled": false,
-        "info": "This sample invokes and displays the results of a `system.applyTag` remote\r\ncommand via the ePO DXL service. The results of the apply command are displayed\r\non the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A ePO DXL service is running and available on the DXL fabric. If version 5.0\r\n  or later of the DXL ePO extensions are installed on your ePO server, an ePO\r\n  DXL service should already be running on the fabric. If you are using an\r\n  earlier version of the DXL ePO extensions, you can use the\r\n  [ePO DXL Python Service](https://github.com/opendxl/opendxl-epo-service-python).\r\n* The DXL client associated with the `Apply system tag in ePO` node is\r\n  authorized to invoke the ePO DXL service, and the user that is connecting to\r\n  the ePO server (within the ePO DXL service) has permission to execute the\r\n  `system.applyTag` remote command (see\r\n  [Client Authorization](https://opendxl.github.io/opendxl-epo-client-python/pydoc/authorization.html)).\r\n\r\n### Setup\r\n\r\n* If more than one ePO service is available on the DXL fabric that the DXL\r\n  client is connecting to, edit the `Apply system tag in ePO` node and set the\r\n  `ePO Id` property to that of the ePO service through which the remote command\r\n  should be performed. By default, the `ePO Id` property is empty, in which case\r\n  the client attempts to dynamically determine the id of the ePO service to\r\n  communicate with.\r\n* Edit the `Specify systems to tag` node and modify the `Payload` property with\r\n  the name(s) of the system(s) to apply the tag to. System names should be\r\n  separated by commas. For example:\r\n\r\n  ```\r\n  system1,system2\r\n  ```\r\n\r\n* Edit the `Apply system tag in ePO` node and modify the `Tag name` property\r\n  with the name of the tag to apply. For example:\r\n\r\n  ```\r\n  mytag1\r\n  ```\r\n  \r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Apply system tag in ePO`\r\n  node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify systems to tag` node.\r\n\r\n### Output\r\n\r\nThe number of systems that the tag was applied to should appear in the Node-RED\r\n`debug` tab. For example:\r\n\r\n```\r\n2\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify systems to tag\r\n\r\nThis is an `inject` input node which starts the flow. This node injects a new\r\nmessage with a `payload` property which specifies the name(s) of the system(s)\r\nto apply the tag to.\r\n\r\n#### Set names request parameter\r\n\r\nThis is a `change` node which copies the value from the `payload` property on\r\nthe message to the `names` property. The `Apply system tag in ePO` node uses the `names` property when\r\nconstructing the parameters for the `system.applyTag` remote command. \r\n\r\n#### Apply system tag in ePO\r\n\r\nThis is an `epo system apply tag` node. This node connects to the DXL fabric and\r\nsends a DXL `Request` message to the ePO service. The message specifies the\r\ntarget remote command as `system.applyTag`.\r\n\r\nThe request message also includes the `msg.names` property set by the\r\n`Set names request parameter` node and the `tagName` set in the\r\n`Tag name` property.\r\n \r\nThe `Return` property is set to \"a parsed JSON object\" and the `Format` property\r\nis set to \"JSON\" to indicate that the payload for the response should be\r\nadded to the output message as a JavaScript object decoded from JSON.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Apply system tag in ePO` node. The output should include\r\nthe response received from the DXL fabric for the `system.applyTag` command."
+        "info": "This sample invokes and displays the results of a `system.applyTag` remote\r\ncommand via the ePO DXL service. The results of the apply command are displayed\r\non the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A ePO DXL service is running and available on the DXL fabric. If version 5.0\r\n  or later of the DXL ePO extensions are installed on your ePO server, an ePO\r\n  DXL service should already be running on the fabric. If you are using an\r\n  earlier version of the DXL ePO extensions, you can use the\r\n  [ePO DXL Python Service](https://github.com/opendxl/opendxl-epo-service-python).\r\n* The DXL client associated with the `Apply system tag in ePO` node is\r\n  authorized to invoke the ePO DXL service, and the user that is connecting to\r\n  the ePO server (within the ePO DXL service) has permission to execute the\r\n  `system.applyTag` remote command (see\r\n  [Client Authorization](https://opendxl.github.io/opendxl-epo-client-python/pydoc/authorization.html)).\r\n\r\n### Setup\r\n\r\n* Edit the `Set system apply tag request parameters` node.\r\n\r\n  * Set the value for the `msg.names` rule to the name(s) of the system(s) that\r\n    the tag should be applied to. If the tag should be applied to more than one\r\n    system, the list of system names should be separated by commas. For example:\r\n\r\n    ```\r\n    system1,system2\r\n    ```\r\n\r\n  * Set the value for the `msg.tagName` rule to the name of the tag which should\r\n    be applied. For example:\r\n  \r\n    ```\r\n    mytag1\r\n    ```\r\n\r\n  * If more than one ePO service is available on the DXL fabric that the DXL\r\n    client is connecting to, set the value for the `msg.epoUniqueId` rule to\r\n    the ID of the ePO service through which the remote command should be\r\n    performed.\r\n \r\n    By default, the `msg.epoUniqueId` property is empty, in which case the\r\n    client attempts to dynamically determine the ID of the ePO service to\r\n    communicate with.\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Apply system tag in ePO`\r\n  node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Start flow` node.\r\n\r\n### Output\r\n\r\nThe number of systems that the tag was newly applied to should appear in the\r\nNode-RED `debug` tab. For example, if the list of system names was\r\n`system1,system2,system3` and the tag had already been applied to `system2`\r\nbut not to `system1` or `system3` before the flow was executed, the following\r\nshould appear in the `debug` tab output:\r\n\r\n```\r\n2\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts the flow.\r\n\r\n#### Set system apply tag request parameters\r\n\r\nThis is a `change` node which sets the names of the system(s) to which the\r\ntag should be applied as the `names` property on the message and the name of\r\nthe tag to apply as the `tagName` property on the message. The\r\n`Apply system tag in ePO` node uses the `names` and `tagName` properties when\r\nconstructing the parameters for the `system.applyTag` remote command. This\r\nnode also sets a value for the `msg.epoUniqueId` property. If the value is\r\nnot empty, it is used as the unique ID of the ePO server which the remote\r\ncommand is sent to.\r\n\r\n#### Apply system tag in ePO\r\n\r\nThis is an `epo system apply tag` node. This node connects to the DXL fabric and\r\nsends a DXL `Request` message to the ePO service. The message specifies the\r\ntarget remote command as `system.applyTag`.\r\n\r\nThe request message also includes the `msg.names` and `msg.tagName` properties\r\nset by the `Set system apply tag request parameters` node.\r\n \r\nThe `Return` property is set to \"a parsed JSON object\" and the `Format` property\r\nis set to \"JSON\" to indicate that the payload for the response should be\r\nadded to the output message as a JavaScript object decoded from JSON.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Apply system tag in ePO` node. The output should include\r\nthe response received from the DXL fabric for the `system.applyTag` command."
     },
     {
-        "id": "a640555e.b6be88",
+        "id": "8de96f05.af828",
         "type": "inject",
-        "z": "a0a509be.5e6768",
-        "name": "Specify systems to tag",
+        "z": "59a70ee6.117af",
+        "name": "Start flow",
         "topic": "",
-        "payload": "<specify-systems-to-tag>",
+        "payload": "",
         "payloadType": "str",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 140,
-        "y": 40,
+        "x": 100,
+        "y": 100,
         "wires": [
             [
-                "8d95edc4.7232b"
+                "f883305b.40d09"
             ]
         ]
     },
     {
-        "id": "71f5d15b.60f4d",
+        "id": "a545df0f.8239c",
         "type": "debug",
-        "z": "a0a509be.5e6768",
+        "z": "59a70ee6.117af",
         "name": "Output result",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "payload",
-        "x": 490,
-        "y": 220,
+        "x": 510,
+        "y": 300,
         "wires": []
     },
     {
-        "id": "fb71c39c.cc3db",
+        "id": "e9f6e9aa.1c4148",
         "type": "dxl-epo-system-apply-tag",
-        "z": "a0a509be.5e6768",
+        "z": "59a70ee6.117af",
         "name": "",
-        "tagName": "<specify-tag-to-apply>",
+        "tagName": "",
         "client": "",
         "epoUniqueId": "",
         "returnType": "obj",
         "x": 290,
-        "y": 220,
+        "y": 300,
         "wires": [
             [
-                "71f5d15b.60f4d"
+                "a545df0f.8239c"
             ]
         ]
     },
     {
-        "id": "8d95edc4.7232b",
+        "id": "f883305b.40d09",
         "type": "change",
-        "z": "a0a509be.5e6768",
-        "name": "Set names request parameter",
+        "z": "59a70ee6.117af",
+        "name": "Set system apply tag request parameters",
         "rules": [
             {
                 "t": "set",
                 "p": "names",
                 "pt": "msg",
-                "to": "payload",
-                "tot": "msg"
+                "to": "<specify-tag-to-apply>",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "tagName",
+                "pt": "msg",
+                "to": "<specify-systems-to-tag>",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "epoUniqueId",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
             }
         ],
         "action": "",
@@ -76,32 +90,22 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 230,
-        "y": 120,
+        "x": 260,
+        "y": 200,
         "wires": [
             [
-                "fb71c39c.cc3db"
+                "e9f6e9aa.1c4148"
             ]
         ]
     },
     {
-        "id": "1e4c19ff.ee0ac6",
+        "id": "c656766f.bb81c8",
         "type": "comment",
-        "z": "a0a509be.5e6768",
-        "name": "Supply the list of systems to tag in the 'Set search text' node ",
+        "z": "59a70ee6.117af",
+        "name": "Supply the list of systems and name of the tag to apply in the 'Set system apply tag request parameters' node",
         "info": "",
-        "x": 500,
+        "x": 390,
         "y": 40,
-        "wires": []
-    },
-    {
-        "id": "68ca8bbb.2a8bb4",
-        "type": "comment",
-        "z": "a0a509be.5e6768",
-        "name": "Supply the tag name in the 'Apply system tag in ePO' node ",
-        "info": "",
-        "x": 370,
-        "y": 280,
         "wires": []
     }
 ]

--- a/examples/basic-system-clear-tag-example.json
+++ b/examples/basic-system-clear-tag-example.json
@@ -1,35 +1,35 @@
 [
     {
-        "id": "bb30832f.dfb2d",
+        "id": "10e0d038.6e2aa",
         "type": "tab",
         "label": "ePO System Clear Tag Example",
         "disabled": false,
-        "info": "This sample invokes and displays the results of a `system.clearTag` remote\r\ncommand via the ePO DXL service. The results of the clear command are displayed\r\non the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A ePO DXL service is running and available on the DXL fabric. If version 5.0\r\n  or later of the DXL ePO extensions are installed on your ePO server, an ePO\r\n  DXL service should already be running on the fabric. If you are using an\r\n  earlier version of the DXL ePO extensions, you can use the\r\n  [ePO DXL Python Service](https://github.com/opendxl/opendxl-epo-service-python).\r\n* The DXL client associated with the `Clear system tag from ePO` node is\r\n  authorized to invoke the ePO DXL service, and the user that is connecting to\r\n  the ePO server (within the ePO DXL service) has permission to execute the\r\n  `system.clearTag` remote command (see\r\n  [Client Authorization](https://opendxl.github.io/opendxl-epo-client-python/pydoc/authorization.html)).\r\n\r\n### Setup\r\n\r\n* If more than one ePO service is available on the DXL fabric that the DXL\r\n  client is connecting to, edit the `Clear system tag from ePO` node and set the\r\n  `ePO Id` property to that of the ePO service through which the remote command\r\n  should be performed. By default, the `ePO Id` property is empty, in which case\r\n  the client attempts to dynamically determine the id of the ePO service to\r\n  communicate with.\r\n* Edit the `Specify systems to clear tag from` node and modify the `Payload`\r\n  property with the name(s) of the system(s) to clear the tag from. System names\r\n  should be separated by commas. For example:\r\n\r\n  ```\r\n  system1,system2\r\n  ```\r\n\r\n* Edit the `Clear system tag from ePO` node and modify the `Tag name` property\r\n  with the name of the tag to clear. For example:\r\n\r\n  ```\r\n  mytag1\r\n  ```\r\n  \r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Clear system tag from ePO`\r\n  node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify systems to clear tag from` node.\r\n\r\n### Output\r\n\r\nThe number of systems that the tag was cleared from should appear in the\r\nNode-RED `debug` tab. For example:\r\n\r\n```\r\n2\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify systems to clear tag from\r\n\r\nThis is an `inject` input node which starts the flow. This node injects a new\r\nmessage with a `payload` property which specifies the name(s) of the system(s)\r\nto clear the tag from.\r\n\r\n#### Set names request parameter\r\n\r\nThis is a `change` node which copies the value from the `payload` property on\r\nthe message to the `names` property. The `Clear system tag from ePO` node uses the `names` property\r\nwhen constructing the parameters for the `system.clearTag` remote command. \r\n\r\n#### Apply system tag in ePO\r\n\r\nThis is an `epo system clear tag` node. This node connects to the DXL fabric and\r\nsends a DXL `Request` message to the ePO service. The message specifies the\r\ntarget remote command as `system.clearTag`.\r\n\r\nThe request message also includes the `msg.names` property set by the\r\n`Set names request parameter` node and the `tagName` set in the\r\n`Tag name` property.\r\n \r\nThe `Return` property is set to \"a parsed JSON object\" and the `Format` property\r\nis set to \"JSON\" to indicate that the payload for the response should be\r\nadded to the output message as a JavaScript object decoded from JSON.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Clear system tag from ePO` node. The output should include\r\nthe response received from the DXL fabric for the `system.clearTag` command."
+        "info": "This sample invokes and displays the results of a `system.clearTag` remote\r\ncommand via the ePO DXL service. The results of the clear command are displayed\r\non the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A ePO DXL service is running and available on the DXL fabric. If version 5.0\r\n  or later of the DXL ePO extensions are installed on your ePO server, an ePO\r\n  DXL service should already be running on the fabric. If you are using an\r\n  earlier version of the DXL ePO extensions, you can use the\r\n  [ePO DXL Python Service](https://github.com/opendxl/opendxl-epo-service-python).\r\n* The DXL client associated with the `Clear system tag from ePO` node is\r\n  authorized to invoke the ePO DXL service, and the user that is connecting to\r\n  the ePO server (within the ePO DXL service) has permission to execute the\r\n  `system.clearTag` remote command (see\r\n  [Client Authorization](https://opendxl.github.io/opendxl-epo-client-python/pydoc/authorization.html)).\r\n\r\n### Setup\r\n\r\n* Edit the `Set system clear tag request parameters` node.\r\n\r\n  * Set the value for the `msg.names` rule to the name(s) of the system(s) that\r\n    the tag should be cleared from. If the tag should be cleared from more than one\r\n    system, the list of system names should be separated by commas. For example:\r\n\r\n    ```\r\n    system1,system2\r\n    ```\r\n\r\n  * Set the value for the `msg.tagName` rule to the name of the tag which should\r\n    be cleared. For example:\r\n  \r\n    ```\r\n    mytag1\r\n    ```\r\n\r\n  * If more than one ePO service is available on the DXL fabric that the DXL\r\n    client is connecting to, set the value for the `msg.epoUniqueId` rule to\r\n    the ID of the ePO service through which the remote command should be\r\n    performed.\r\n \r\n    By default, the `msg.epoUniqueId` property is empty, in which case the\r\n    client attempts to dynamically determine the ID of the ePO service to\r\n    communicate with.\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Clear system tag from ePO`\r\n  node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Start flow` node.\r\n\r\n### Output\r\n\r\nThe number of systems that the tag was cleared from should appear in the\r\nNode-RED `debug` tab. For example, if the list of system names was\r\n`system1,system2,system3` and the tag had already been applied to `system1` and\r\n`system3` but not to `system2` before the flow was executed, the following\r\nshould appear in the `debug` tab output:\r\n\r\n```\r\n2\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts the flow.\r\n\r\n#### Set system clear tag request parameters\r\n\r\nThis is a `change` node which sets the names of the system(s) which the\r\ntag should be cleared from as the `names` property on the message and the name\r\nof the tag to clear as the `tagName` property on the message. The\r\n`Clear system tag from ePO` node uses the `names` and `tagName` properties when\r\nconstructing the parameters for the `system.clearTag` remote command. This\r\nnode also sets a value for the `msg.epoUniqueId` property. If the value is\r\nnot empty, it is used as the unique ID of the ePO server which the remote\r\ncommand is sent to.\r\n\r\n#### Clear system tag from ePO\r\n\r\nThis is an `epo system clear tag` node. This node connects to the DXL fabric and\r\nsends a DXL `Request` message to the ePO service. The message specifies the\r\ntarget remote command as `system.clearTag`.\r\n\r\nThe request message also includes the `msg.names` and `msg.tagName` properties\r\nset by the `Set system clear tag request parameters` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" and the `Format` property\r\nis set to \"JSON\" to indicate that the payload for the response should be\r\nadded to the output message as a JavaScript object decoded from JSON.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Clear system tag from ePO` node. The output should include\r\nthe response received from the DXL fabric for the `system.clearTag` command."
     },
     {
-        "id": "f4f8e30.f181c2",
+        "id": "16c1a6be.cbfd19",
         "type": "inject",
-        "z": "bb30832f.dfb2d",
-        "name": "Specify systems to clear tag from",
+        "z": "10e0d038.6e2aa",
+        "name": "Start flow",
         "topic": "",
-        "payload": "<specify-systems-to-clear-tag-from>",
+        "payload": "",
         "payloadType": "str",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 170,
+        "x": 100,
         "y": 100,
         "wires": [
             [
-                "a61a3c23.c794e"
+                "f45beb95.138e58"
             ]
         ]
     },
     {
-        "id": "9239497c.8ae8a8",
+        "id": "89db8302.57d8d",
         "type": "debug",
-        "z": "bb30832f.dfb2d",
+        "z": "10e0d038.6e2aa",
         "name": "Output result",
         "active": true,
         "tosidebar": true,
@@ -41,33 +41,41 @@
         "wires": []
     },
     {
-        "id": "c135ab73.671a08",
+        "id": "593ca3cd.43429c",
         "type": "dxl-epo-system-clear-tag",
-        "z": "bb30832f.dfb2d",
+        "z": "10e0d038.6e2aa",
         "name": "",
-        "tagName": "<specify-tag-to-clear>",
+        "tagName": "",
         "client": "",
+        "epoUniqueId": "",
         "returnType": "obj",
         "x": 320,
         "y": 300,
         "wires": [
             [
-                "9239497c.8ae8a8"
+                "89db8302.57d8d"
             ]
         ]
     },
     {
-        "id": "a61a3c23.c794e",
+        "id": "f45beb95.138e58",
         "type": "change",
-        "z": "bb30832f.dfb2d",
-        "name": "Set names request parameter",
+        "z": "10e0d038.6e2aa",
+        "name": "Set system clear tag request parameters",
         "rules": [
             {
                 "t": "set",
                 "p": "names",
                 "pt": "msg",
-                "to": "payload",
-                "tot": "msg"
+                "to": "<specify-tag-to-clear>",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "tagName",
+                "pt": "msg",
+                "to": "<specify-systems-to-clear-tag-from>",
+                "tot": "str"
             }
         ],
         "action": "",
@@ -75,32 +83,22 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 250,
+        "x": 260,
         "y": 200,
         "wires": [
             [
-                "c135ab73.671a08"
+                "593ca3cd.43429c"
             ]
         ]
     },
     {
-        "id": "8c1f2641.e0e7f8",
+        "id": "376512b2.415eee",
         "type": "comment",
-        "z": "bb30832f.dfb2d",
-        "name": "Supply the list of systems to untag in the 'Set search text' node ",
+        "z": "10e0d038.6e2aa",
+        "name": "Supply the list of systems and name of the tag to clear in the 'Set system clear tag request parameters' node",
         "info": "",
-        "x": 240,
+        "x": 390,
         "y": 40,
-        "wires": []
-    },
-    {
-        "id": "f6fe83e6.70cd2",
-        "type": "comment",
-        "z": "bb30832f.dfb2d",
-        "name": "Supply the tag name in the 'Clear system tag from ePO' node ",
-        "info": "",
-        "x": 400,
-        "y": 360,
         "wires": []
     }
 ]

--- a/examples/basic-system-find-example.json
+++ b/examples/basic-system-find-example.json
@@ -1,35 +1,35 @@
 [
     {
-        "id": "755bd09c.cc637",
+        "id": "3a7c0e06.a1a222",
         "type": "tab",
         "label": "ePO System Find Example",
         "disabled": false,
-        "info": "This sample invokes and displays the results of a `system.find` remote command\r\nvia the ePO DXL service. The results of the find command are displayed on the\r\nNode-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A ePO DXL service is running and available on the DXL fabric. If version 5.0\r\n  or later of the DXL ePO extensions are installed on your ePO server, an ePO\r\n  DXL service should already be running on the fabric. If you are using an\r\n  earlier version of the DXL ePO extensions, you can use the\r\n  [ePO DXL Python Service](https://github.com/opendxl/opendxl-epo-service-python).\r\n* The DXL client associated with the `Find systems in ePO` node is\r\n  authorized to invoke the ePO DXL service, and the user that is connecting to\r\n  the ePO server (within the ePO DXL service) has permission to execute the\r\n  `system.find` remote command (see\r\n  [Client Authorization](https://opendxl.github.io/opendxl-epo-client-python/pydoc/authorization.html)).\r\n\r\n### Setup\r\n\r\n* If more than one ePO service is available on the DXL fabric that the DXL\r\n  client is connecting to, edit the `Find systems in ePO` node and set the\r\n  `ePO Id` property to that of the ePO service through which the remote command\r\n  should be performed. By default, the `ePO Id` property is empty, in which case\r\n  the client attempts to dynamically determine the id of the ePO service to\r\n  communicate with.\r\n* Edit the `Specify search text` node and modify the `Payload` property with\r\n  the search text to use for the system find command. For example:\r\n\r\n  ```\r\n  broker\r\n  ```\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Find systems in ePO` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify search text` node.\r\n\r\n### Output\r\n\r\nThe following output should appear in the Node-RED `debug` tab:\r\n\r\n```\r\n▶ [ object ]\r\n```\r\n\r\nAfter clicking on the right arrow button to expand the contents of the object,\r\noutput similar to the following should appear:\r\n\r\n```\r\n▼ array[1]\r\n ▼ 0: object\r\n    EPOComputerProperties.ParentID: 2\r\n    EPOComputerProperties.ComputerName\": \"mysystem\",\r\n    EPOComputerProperties.Description\": null,\r\n...\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify search text\r\n\r\nThis is an `inject` input node which starts the flow. This node injects a new\r\nmessage with a `payload` property which specifies the search text to use for the\r\nsystem find command.\r\n\r\n#### Set searchText request parameter\r\n\r\nThis is a `change` node which copies the value from the `payload` property on\r\nthe message to the `searchText` property. The `Find systems in ePO` node uses the `searchText` property when constructing\r\nthe parameters for the `system.find` remote command. \r\n\r\n#### Find systems in ePO\r\n\r\nThis is an `epo system find` node. This node connects to the DXL fabric and\r\nsends a DXL `Request` message to the ePO service. The message specifies the\r\ntarget remote command as `system.find`.\r\n\r\nThe request message also includes the `msg.searchText` property set by the\r\n`Set searchText request parameter` node.\r\n \r\nThe `Return` property is set to \"a parsed JSON object\" and the `Format` property\r\nis set to \"JSON\" to indicate that the payload for the response should be\r\nadded to the output message as a JavaScript object decoded from JSON.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Find systems in ePO` node. The output should include\r\nthe response received from the DXL fabric for the `system.find` command."
+        "info": "This sample invokes and displays the results of a `system.find` remote command\r\nvia the ePO DXL service. The results of the find command are displayed on the\r\nNode-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A ePO DXL service is running and available on the DXL fabric. If version 5.0\r\n  or later of the DXL ePO extensions are installed on your ePO server, an ePO\r\n  DXL service should already be running on the fabric. If you are using an\r\n  earlier version of the DXL ePO extensions, you can use the\r\n  [ePO DXL Python Service](https://github.com/opendxl/opendxl-epo-service-python).\r\n* The DXL client associated with the `Find systems in ePO` node is\r\n  authorized to invoke the ePO DXL service, and the user that is connecting to\r\n  the ePO server (within the ePO DXL service) has permission to execute the\r\n  `system.find` remote command (see\r\n  [Client Authorization](https://opendxl.github.io/opendxl-epo-client-python/pydoc/authorization.html)).\r\n\r\n### Setup\r\n\r\n* Edit the `Set system find request parameters` node.\r\n\r\n  * Set the value for the `msg.searchText` rule to the search text to use for\r\n    the system find command. For example:\r\n\r\n    ```\r\n    broker\r\n    ```\r\n\r\n  * If more than one ePO service is available on the DXL fabric that the DXL\r\n    client is connecting to, set the value for the `msg.epoUniqueId` rule to\r\n    the ID of the ePO service through which the remote command should be\r\n    performed.\r\n \r\n    By default, the `msg.epoUniqueId` property is empty, in which case the\r\n    client attempts to dynamically determine the ID of the ePO service to\r\n    communicate with.\r\n\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Find systems in ePO` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Start flow` node.\r\n\r\n### Output\r\n\r\nThe following output should appear in the Node-RED `debug` tab:\r\n\r\n```\r\n▶ [ object ]\r\n```\r\n\r\nAfter clicking on the right arrow button to expand the contents of the object,\r\noutput similar to the following should appear:\r\n\r\n```\r\n▼ array[1]\r\n ▼ 0: object\r\n    EPOComputerProperties.ParentID: 2\r\n    EPOComputerProperties.ComputerName\": \"mysystem\",\r\n    EPOComputerProperties.Description\": null,\r\n...\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts the flow.\r\n\r\n#### Set system find request parameters\r\n\r\nThis is a `change` node which sets the search text to use for the system(s)\r\nto find as the `searchText` property on the message. This node also sets a value\r\nfor the `msg.epoUniqueId` property. If the value is not empty, it is used as the\r\nunique ID of the ePO server which the remote command is sent to.\r\n\r\n#### Find systems in ePO\r\n\r\nThis is an `epo system find` node. This node connects to the DXL fabric and\r\nsends a DXL `Request` message to the ePO service. The message specifies the\r\ntarget remote command as `system.find`.\r\n\r\nThe request message also includes the `msg.searchText` property set by the\r\n`Set system find request parameters` node.\r\n \r\nThe `Return` property is set to \"a parsed JSON object\" and the `Format` property\r\nis set to \"JSON\" to indicate that the payload for the response should be\r\nadded to the output message as a JavaScript object decoded from JSON.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Find systems in ePO` node. The output should include\r\nthe response received from the DXL fabric for the `system.find` command."
     },
     {
-        "id": "de9bfc36.37b79",
+        "id": "90ca5c31.613bb",
         "type": "inject",
-        "z": "755bd09c.cc637",
-        "name": "Specify search text",
+        "z": "3a7c0e06.a1a222",
+        "name": "Start flow",
         "topic": "",
-        "payload": "<specify-search-text>",
+        "payload": "",
         "payloadType": "str",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 130,
+        "x": 100,
         "y": 100,
         "wires": [
             [
-                "1f5b2965.ad3a37"
+                "82a674c.af10188"
             ]
         ]
     },
     {
-        "id": "48ea0eb7.60122",
+        "id": "340219c6.c51936",
         "type": "debug",
-        "z": "755bd09c.cc637",
+        "z": "3a7c0e06.a1a222",
         "name": "Output systems",
         "active": true,
         "tosidebar": true,
@@ -41,9 +41,9 @@
         "wires": []
     },
     {
-        "id": "1952295b.b0bb07",
+        "id": "f1be385f.4f4cb8",
         "type": "dxl-epo-system-find",
-        "z": "755bd09c.cc637",
+        "z": "3a7c0e06.a1a222",
         "name": "",
         "client": "",
         "searchNameOnly": "",
@@ -53,22 +53,22 @@
         "y": 300,
         "wires": [
             [
-                "48ea0eb7.60122"
+                "340219c6.c51936"
             ]
         ]
     },
     {
-        "id": "1f5b2965.ad3a37",
+        "id": "82a674c.af10188",
         "type": "change",
-        "z": "755bd09c.cc637",
-        "name": "Set searchText request parameter",
+        "z": "3a7c0e06.a1a222",
+        "name": "Set system find request parameters",
         "rules": [
             {
                 "t": "set",
                 "p": "searchText",
                 "pt": "msg",
-                "to": "payload",
-                "tot": "msg"
+                "to": "<specify-search-text>",
+                "tot": "str"
             },
             {
                 "t": "set",
@@ -76,6 +76,13 @@
                 "pt": "msg",
                 "to": "false",
                 "tot": "bool"
+            },
+            {
+                "t": "set",
+                "p": "epoUniqueId",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
             }
         ],
         "action": "",
@@ -87,14 +94,14 @@
         "y": 200,
         "wires": [
             [
-                "1952295b.b0bb07"
+                "f1be385f.4f4cb8"
             ]
         ]
     },
     {
-        "id": "e90ed2b0.4c4e2",
+        "id": "2afe3130.3cefbe",
         "type": "comment",
-        "z": "755bd09c.cc637",
+        "z": "3a7c0e06.a1a222",
         "name": "Supply the system search text to use in the 'Set search text' node",
         "info": "",
         "x": 250,

--- a/nodes/dxl-epo-system-find.js
+++ b/nodes/dxl-epo-system-find.js
@@ -17,6 +17,8 @@ module.exports = function (RED) {
    * @param {Object} nodeConfig - Configuration data which the node uses.
    * @param {String} nodeConfig.client - Id of the DXL client configuration node
    *   that this node should be associated with.
+   * @param {(String|Object)} [nodeConfig.searchText] - Search text for the
+   *   system(s) to find.
    * @param {(Number|Boolean)} [nodeConfig.searchNameOnly=0] - For a value of
    *   `1` or `true`, search only the system name field for the search text. For
    *   a value of `0` or `false`, search all system fields for the search text.


### PR DESCRIPTION
Previously, the parameters used in ePO requests in the examples could be
set across multiple nodes within the flow - the starting inject node, a
change node, and/or the request node itself. In this commit, the
examples have been updated to uniformly set all of the available ePO
request parameters from within the change node which immediately
precedes the ePO request node in the flow.